### PR TITLE
Title raw field in dd for auto-complete

### DIFF
--- a/template.json
+++ b/template.json
@@ -53,6 +53,18 @@
                   "format": "strict_date_optional_time||epoch_millis"
                 }
               }
+            },
+            "title": {
+              "type": "string",
+              "store": true,
+              "term_vector": "with_positions_offsets",
+              "analyzer": "snowball",
+              "fields": {
+                "raw": {
+                  "index": "not_analyzed",
+                  "type": "string"
+                }
+              }
             }
           }
         },
@@ -92,7 +104,13 @@
               "type": "string",
               "store": true,
               "term_vector": "with_positions_offsets",
-              "analyzer": "snowball"
+              "analyzer": "snowball",
+              "fields": {
+                "raw": {
+                  "index": "not_analyzed",
+                  "type": "string"
+                }
+              }
             },
             "type": {
               "type": "string",


### PR DESCRIPTION
### What

Updated template to add raw values for the titles of areas and datasets so that they can be searched. Snowball analyzer tokenises each word inside a string so adding a raw value allows the return of just the original title and not the split up strings.

### How to review

- delete any templates you may have already: `DELETE /_template/*`
- delete the datasets index: `DELETE /dd`
- delete the areas index: `DELETE /areas`
- Upload the new template from inside the directory with `curl -XPUT localhost:9200/_template/base -d @template.json`
- Run the importer.
- Import datasets with the datasets importers.
- Use the following search to find datasets that have "house" in the title:

`GET /dd/_search?`
```json
{"size": 0,
   "query": {
      "bool": {
         "should": [
            {
               "match_phrase_prefix": {
                  "body.title": {
                     "query": "hours"
                  }
               }
            },
            {
               "prefix": {
                  "body.title.raw": "search_term",
                  "boost": 20
               }
            }
         ]
      }
   },
   "aggs": {
      "products": {
         "terms": {
            "field": "body.title.raw",
            "size": 10
         }
      }
   }
}
```

### Who can review

@CarlHembrough 
