### PR TITLE
Add geography summary with area types to the model. 

### DIFF
--- a/model/document.go
+++ b/model/document.go
@@ -13,11 +13,24 @@ type Area struct {
 }
 
 type Dataset struct {
-	ID         string       `json:"id"`
-	Title      string       `json:"title"`
-	URL        string       `json:"url,omitempty"`
-	Metadata   *Metadata    `json:"metadata,omitempty"`
-	Dimensions []*Dimension `json:"dimensions,omitempty"`
+	ID                  string                        `json:"id"`
+	Title               string                        `json:"title"`
+	URL                 string                        `json:"url,omitempty"`
+	Metadata            *Metadata                     `json:"metadata,omitempty"`
+	Dimensions          []*Dimension                  `json:"dimensions,omitempty"`
+	GeographicHierarchy []*GeographicHierarchySummary `json:"geographic_hierarchy,omitempty"`
+}
+
+type GeographicHierarchySummary struct {
+	ID        string      `json:"id"`
+	Title     string      `json:"title"`
+	AreaTypes []*AreaType `json:"area_types"`
+}
+
+type AreaType struct {
+	ID    string `json:"id"`
+	Title string `json:"title"`
+	Level int    `json:"level"`
 }
 
 type Metadata struct {

--- a/template.json
+++ b/template.json
@@ -39,6 +39,43 @@
                 }
               }
             },
+            "geographic_hierarchy": {
+              "type": "nested",
+              "properties": {
+                "area_types": {
+                  "type": "nested",
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "store": true,
+                      "term_vector": "with_positions_offsets",
+                      "analyzer": "snowball"
+                    },
+                    "level": {
+                      "type": "long"
+                    },
+                    "title": {
+                      "type": "string",
+                      "store": true,
+                      "term_vector": "with_positions_offsets",
+                      "analyzer": "snowball"
+                    }
+                  }
+                },
+                "id": {
+                  "type": "string",
+                  "store": true,
+                  "term_vector": "with_positions_offsets",
+                  "analyzer": "snowball"
+                },
+                "title": {
+                  "type": "string",
+                  "store": true,
+                  "term_vector": "with_positions_offsets",
+                  "analyzer": "snowball"
+                }
+              }
+            },
             "id": {
               "type": "string",
               "index": "not_analyzed"
@@ -87,10 +124,6 @@
               "store": true,
               "term_vector": "with_positions_offsets",
               "analyzer": "snowball"
-            },
-            "geography_id": {
-              "type": "string",
-              "index": "not_analyzed"
             },
             "id": {
               "type": "string",


### PR DESCRIPTION


### What

Add geography summary with area types to the model. Updated the template mapping to map geographic hierarchies and area types as nested objects allowing them to be individually queried instead of flattened.

### How to review

Ensure that when the template is loaded that the hierarchies and area type within a dataset are mapped as nested objects.

### Who can review

@githubmo 
